### PR TITLE
Change dmc urls to lmc, remove locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Welcome to the Microsoft Edge WebDriver repository.
 
-This is a place for all users of [Microsoft Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) to send ideas, feedback, suggestions, bugs, and also ask questions or have discussions.
+This is a place for all users of [Microsoft Edge WebDriver](https://developer.microsoft.com/microsoft-edge/tools/webdriver/) to send ideas, feedback, suggestions, bugs, and also ask questions or have discussions.
 
 * 📢 [Open a new issue](https://github.com/MicrosoftEdge/EdgeWebDriver/issues/new/choose)
 * 🔎 [Search for existing issues](https://github.com/MicrosoftEdge/EdgeWebDriver/issues)
-* 📗 [Learn how to write automated tests for Microsoft Edge using WebDriver](https://docs.microsoft.com/en-us/microsoft-edge/webdriver-chromium)
-* 💾 [Download driver binaries for Microsoft Edge](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
+* 📗 [Learn how to write automated tests for Microsoft Edge using WebDriver](https://learn.microsoft.com/microsoft-edge/webdriver-chromium)
+* 💾 [Download driver binaries for Microsoft Edge](https://developer.microsoft.com/microsoft-edge/tools/webdriver/)
 
 ## Resources
 
@@ -29,6 +29,6 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
 trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://learn.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
 
@@ -36,6 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/msrc/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
URLs update/cleanup as part of a sweep of MicrosoftEdge org repo's:
* Changed docs.microsoft.com to learn.microsoft.com.
* Removed /en-us/ locale after testing each site without it.

No other changes.